### PR TITLE
Refactor into a memory safe, more idiomatic solution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,11 +139,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-format"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71a5df8a0f4b423e8bc25526b39852bf64dfb7bd734ed99ed343c5925762c9c8"
+
+[[package]]
 name = "flyser"
 version = "0.1.0"
 dependencies = [
  "clap",
  "create",
+ "file-format",
  "termion",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.2.7", features = ["derive"] }
 create = "0.1.0"
+file-format = "0.16.0"
 termion = "2.0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ use std::{
 use clap::Parser;
 use file_format::FileFormat;
 
+const DEFAULT_FALIURE: &str = "Unknown";
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -18,6 +20,10 @@ fn main() {
     file_path.push(&args.file_name);
 
     let file_name = args.file_name;
+    let file_extension = match file_path.extension() {
+        Some(ext) => ext.to_str().unwrap_or(DEFAULT_FALIURE),
+        None => DEFAULT_FALIURE
+    };
 
     let file = File::open(&file_path).expect("Failed to open the file");
     let file_buffer = BufReader::new(&file);
@@ -31,21 +37,60 @@ fn main() {
         (counts.0 + 1, counts.1 + line_words.len(), counts.2 + line_chars.len())
     });
 
-    let file_size = metadata(&file_path).expect("Error retrieving file metadata").len();
+    let file_size = metadata(&file_path).expect("Error retrieving file metadata").len() as f64 / 1_048_576.0;
 
     let file_type = match FileFormat::from_file(file_path.clone()) {
-        Ok(format) => format.name().to_owned(),
-        Err(_) => String::from("Unknown")
+        Ok(format) => {
+            let format = format.name().to_owned();
+            if format == *"Arbitrary Binary Data" {
+                get_type_from_ext(file_extension).to_string()
+            } else {
+                format
+            }
+        }
+        Err(_) => String::from(DEFAULT_FALIURE)
     };
 
     println!("[Flyser :3]\n");
     println!("File name: {}", file_name);
     println!("File type: {}", file_type);
-    println!("File path: {:?}", file_path);
+    println!("File path: {}", file_path.to_str().unwrap_or(DEFAULT_FALIURE));
 
     println!("\nFile size: {:.5} MB", file_size);
 
     println!("\nTotal number of lines: {}", line_count);
     println!("Total number or words: {}", word_count);
     println!("Total number of characters: {}", char_count);
+}
+
+pub fn get_type_from_ext(ext: &str) -> &str {
+    match ext {
+        "rs" => "Rust (rs)",
+        "py" => "Python (py)",
+        "html" => "HyperText Markup Language (html)",
+        "css" => "Cascading Style Sheets (css)",
+        "scss" => "Syntactically Awesome Style Sheets (scss)",
+        "jar" => "Java (jar)",
+        "java" => "Java (java)",
+        "cpp" => "C++ (cpp)",
+        "js" => "JavaScript (js)",
+        "ts" => "TypeScript (ts)",
+        "php" => "PHP (php)",
+        "swift" => "Swift (swift)",
+        "go" => "Go (go)",
+        "rb" => "Ruby (rb)",
+        "c" => "C (c)",
+        "cs" => "C# (cs)",
+        "csx" => "C# (csx)",
+        "vb" => "Visual Basic (vb)",
+        "kt" => "Kotlin (kt)",
+        "r" => "R (r)",
+        "m" => "MATLAB (m)",
+        "sql" => "SQL (sql)",
+        "sh" => "Shell Script (sh)",
+        "bat" => "Batch (bat)",
+        "ps1" => "PowerShell (ps1)",
+
+        _ => DEFAULT_FALIURE
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,101 +4,48 @@ use std::{
     env,
 };
 use clap::Parser;
-use file_format::{FileFormat, Kind};
+use file_format::FileFormat;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    name: String,
+    file_name: String,
 }
 
 fn main() {
     let args = Args::parse();
-    let mut cur_path = env::current_dir().unwrap();
-    cur_path.push(&args.name);
+    let mut file_path = env::current_dir().unwrap();
+    file_path.push(&args.file_name);
 
-    let name = cur_path.file_name().unwrap().to_str().unwrap();
-    let path = cur_path.as_os_str().to_str().unwrap();
-    let in_ext = cur_path.extension().unwrap().to_str().unwrap();
-    
-    let file_p = &args.name;
+    let file_name = args.file_name;
 
-    let file = match File::open(file_p) {
-        Ok(file) => file,
-        Err(err) => {
-            eprintln!("Error opening file:\n{}", err);
-            std::process::exit(1);
-        }
+    let file = File::open(&file_path).expect("Failed to open the file");
+    let file_buffer = BufReader::new(&file);
+
+    let (line_count, word_count, char_count) = file_buffer.lines().fold((0, 0, 0), |counts, line_result| {
+        let line = line_result.unwrap_or_else(|_| String::new());
+
+        let line_chars: Vec<char> = line.chars().collect();
+        let line_words: Vec<&str> = line.split_whitespace().collect();
+
+        (counts.0 + 1, counts.1 + line_words.len(), counts.2 + line_chars.len())
+    });
+
+    let file_size = metadata(&file_path).expect("Error retrieving file metadata").len();
+
+    let file_type = match FileFormat::from_file(file_path.clone()) {
+        Ok(format) => format.name().to_owned(),
+        Err(_) => String::from("Unknown")
     };
-    
-    let filer = BufReader::new(file);
-
-    let mut line_count = 0;
-    let mut word_count = 0;
-    let mut char_count = 0;
-
-    for line in filer.lines() {
-        if let Ok(line) = line {
-            line_count += 1;
-            word_count += line.split_whitespace().count();
-            char_count += line.chars().count();
-        }
-    }
-
-    match std::fs::metadata(file_p) {
-        Ok(metadata) => metadata,
-        Err(err) => {
-            panic!("Error retrieving file metadata:\n{}", err);
-        }
-    };
-
-    let file_size_byte: u64 = metadata(file_p).unwrap().len();
-    let file_size: f64 = file_size_byte as f64 / 1_048_576.0;
-
-    let ext = get_ext(in_ext);
-
 
     println!("[Flyser :3]\n");
-    println!("File name: {}", name);
-    println!("File extension: {}", ext);
-    println!("File path: {}", path);
+    println!("File name: {}", file_name);
+    println!("File type: {}", file_type);
+    println!("File path: {:?}", file_path);
 
     println!("\nFile size: {:.5} MB", file_size);
 
     println!("\nTotal number of lines: {}", line_count);
     println!("Total number or words: {}", word_count);
     println!("Total number of characters: {}", char_count);
-}
-
-
-fn get_ext(ext: &str) -> &str {
-    match ext {
-        "rs" => return "Rust (rs)",
-        "py" => return "Python (py)",
-        "html" => return "HyperText Markup Language (html)",
-        "css" => return "Cascading Style Sheets (css)",
-        "scss" => return "Syntactically Awesome Style Sheets (scss)",
-        "jar" => return "Java (jar)",
-        "java" => return "Java (java)",
-        "cpp" => return "C++ (cpp)",
-        "js" => return "JavaScript (js)",
-        "ts" => return "TypeScript (ts)",
-        "php" => return "PHP (php)",
-        "swift" => return "Swift (swift)",
-        "go" => return "Go (go)",
-        "rb" => return "Ruby (rb)",
-        "c" => return "C (c)",
-        "cs" => return "C# (cs)",
-        "csx" => return "C# (csx)",
-        "vb" => return "Visual Basic (vb)",
-        "kt" => return "Kotlin (kt)",
-        "r" => return "R (r)",
-        "m" => return "MATLAB (m)",
-        "sql" => return "SQL (sql)",
-        "sh" => return "Shell Script (sh)",
-        "bat" => return "Batch (bat)",
-        "ps1" => return "PowerShell (ps1)",
-
-        _ => return "Unknow"
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
-use std;
-use std::fs::File;
-use std::env;
-use std::io::{BufRead, BufReader};
-use std::fs::metadata;
+use std::{
+    fs::{File,metadata},
+    io::{BufRead, BufReader},
+    env,
+};
 use clap::Parser;
+use file_format::{FileFormat, Kind};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]


### PR DESCRIPTION
The current version uses `std::process::exit()` which doesn't call destructors, leaking memory on failure. This refactor also doesn't use any `unwraps` or `expects` so it should be much harder to crash. Dead code has been removed and old code has been refactored to be more idiomatic.